### PR TITLE
feat : JaCoCo 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,21 +21,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-tasks.named('test') {
+test{
 	useJUnitPlatform()
-}
-
-test {
-	finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-	dependsOn test
+	finalizedBy 'jacocoTestReport'
 }
 
 jacoco {
 	toolVersion = "0.8.7"
-	reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+	reportsDirectory = layout.buildDirectory.dir('jacocoDir')
 }
 
 jacocoTestReport {
@@ -43,5 +36,32 @@ jacocoTestReport {
 		xml.required = false
 		csv.required = false
 		html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+	}
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			// 클래스 단위로 커버리지 체크
+			element = 'CLASS'
+
+			// 라인 커버리지 제한을 90%로 설정
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.90
+			}
+
+			// 브랜치 커버리지 제한을 90%로 설정
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.90
+			}
+
+			excludes = ["*.YanawaserverApplication"]
+		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.6.9'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'fashionable.simba'
@@ -22,4 +23,25 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+}
+
+jacoco {
+	toolVersion = "0.8.7"
+	reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+}
+
+jacocoTestReport {
+	reports {
+		xml.required = false
+		csv.required = false
+		html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+	}
 }


### PR DESCRIPTION
코드 커버리지 측정을 위해 JaCoCo 라이브러리를 추가했습니다. 

`./gradlew test` 명령어를 사용하면 JaCoCo 테스트가 실행됩니다.

제가 설정한 단위는 클래스이고 라인 커버리지와 브랜치 커버리지가 90퍼센트를 넘어야 합니다.

```yaml
// 클래스 단위로 커버리지 체크
element = 'CLASS'

// 라인 커버리지 제한을 90%로 설정
limit {
counter = 'LINE'
value = 'COVEREDRATIO'
minimum = 0.90
}

// 브랜치 커버리지 제한을 90%로 설정
limit {
counter = 'BRANCH'
value = 'COVEREDRATIO'
minimum = 0.90
}
```